### PR TITLE
refactor(Task): add category & date fields with test fixture updates

### DIFF
--- a/src/components/tests/tasklist/Task.count.spec.ts
+++ b/src/components/tests/tasklist/Task.count.spec.ts
@@ -1,13 +1,10 @@
-import {
-  type DatedTask,
-  countAll,
-  countCompleted,
-  countTodo,
-} from "@/utils/Tasklist";
+import { Task } from "@/components/tests/tasks/Task";
+import { countAll, countCompleted, countTodo } from "@/utils/Tasklist";
 
-const make = (overrides: Partial<DatedTask> = {}): DatedTask => ({
+const make = (overrides: Partial<Task> = {}): Task => ({
   id: 1,
   title: "Default",
+  category: "none",
   completed: false,
   date: new Date("2025-09-23T09:00:00Z"),
   ...overrides,

--- a/src/components/tests/tasklist/Task.filter.spec.ts
+++ b/src/components/tests/tasklist/Task.filter.spec.ts
@@ -1,8 +1,10 @@
-import { type DatedTask, filterCompleted, filterTodo } from "@/utils/Tasklist";
+import { Task } from "@/components/tests/tasks/Task";
+import { filterCompleted, filterTodo } from "@/utils/Tasklist";
 
-const make = (overrides: Partial<DatedTask> = {}): DatedTask => ({
+const make = (overrides: Partial<Task> = {}): Task => ({
   id: 1,
   title: "Default",
+  category: "none",
   completed: false,
   date: new Date("2025-09-23T09:00:00Z"),
   ...overrides,
@@ -10,7 +12,7 @@ const make = (overrides: Partial<DatedTask> = {}): DatedTask => ({
 
 describe("filterCompleted", () => {
   it("filtrerar ut de färdiga uppgifterna", () => {
-    const input: DatedTask[] = [
+    const input: Task[] = [
       make({ id: 2, title: "Handla", completed: true }),
       make({ id: 1, title: "Städa", completed: true }),
       make({ id: 3, title: "Tvätta", completed: false }),
@@ -30,7 +32,7 @@ describe("filterCompleted", () => {
 
 describe("filterTodo", () => {
   it("filtrerar ut de uppgifterna som ska göras", () => {
-    const input: DatedTask[] = [
+    const input: Task[] = [
       make({ id: 2, title: "Handla", completed: false }),
       make({ id: 1, title: "Städa", completed: true }),
       make({ id: 3, title: "Tvätta", completed: false }),

--- a/src/components/tests/tasklist/Task.sort.spec.ts
+++ b/src/components/tests/tasklist/Task.sort.spec.ts
@@ -1,13 +1,10 @@
-import {
-  type DatedTask,
-  sortByDateAsc,
-  sortByDateDesc,
-  sortByTitle,
-} from "@/utils/Tasklist";
+import { Task } from "@/components/tests/tasks/Task";
+import { sortByDateAsc, sortByDateDesc, sortByTitle } from "@/utils/Tasklist";
 
-const make = (overrides: Partial<DatedTask> = {}): DatedTask => ({
+const make = (overrides: Partial<Task> = {}): Task => ({
   id: 1,
   title: "Aplpha",
+  category: "none",
   completed: false,
   date: new Date("2025-09-23T09:00:00Z"),
   ...overrides,
@@ -15,7 +12,7 @@ const make = (overrides: Partial<DatedTask> = {}): DatedTask => ({
 
 describe("sortByTitle", () => {
   it("sorterar alfabetiskt (sv)", () => {
-    const input: DatedTask[] = [
+    const input: Task[] = [
       make({ id: 2, title: "Handla" }),
       make({ id: 1, title: "Städa" }),
       make({ id: 3, title: "Tvätta" }),

--- a/src/components/tests/tasks/Task.completed.spec.ts
+++ b/src/components/tests/tasks/Task.completed.spec.ts
@@ -1,8 +1,20 @@
 import { type Task, setTaskCompleted, toggleTaskCompleted } from "./Task";
 
 const fresh = (): Task[] => [
-  { id: 1, title: "Köp mjölk", completed: false },
-  { id: 2, title: "Städa", completed: true },
+  {
+    id: 1,
+    title: "Köp mjölk",
+    category: "Shop", //lagt till category och date - inget annat ändrat
+    date: new Date("2025-09-24"),
+    completed: false,
+  },
+  {
+    id: 2,
+    title: "Städa",
+    category: "Shop", //lagt till category och date - inget annat ändrat
+    date: new Date("2025-09-24"),
+    completed: true,
+  },
 ];
 
 describe("toggleTaskCompleted", () => {

--- a/src/components/tests/tasks/Task.delete.spec.ts
+++ b/src/components/tests/tasks/Task.delete.spec.ts
@@ -1,9 +1,27 @@
 import { type Task, deleteTask } from "./Task";
 
 const base = (): Task[] => [
-  { id: 1, title: "Köp mjölk", completed: false },
-  { id: 2, title: "Städa", completed: true },
-  { id: 3, title: "Diska", completed: false },
+  {
+    id: 1,
+    title: "Köp mjölk",
+    category: "Shop",
+    date: new Date("2025-09-24"),
+    completed: false,
+  },
+  {
+    id: 2,
+    title: "Städa",
+    category: "Shop", //lagt till category och date - inget annat ändrat
+    date: new Date("2025-09-24"),
+    completed: true,
+  },
+  {
+    id: 3,
+    title: "Diska",
+    category: "Shop", //lagt till category och date - inget annat ändrat
+    date: new Date("2025-09-24"),
+    completed: false,
+  },
 ];
 
 describe("deleteTask", () => {

--- a/src/components/tests/tasks/Task.ts
+++ b/src/components/tests/tasks/Task.ts
@@ -1,6 +1,7 @@
 export interface Task {
   id: number;
   title: string;
+  category: string;
   completed: boolean;
   date: Date;
 }

--- a/src/components/tests/tasks/Task.update.spec.ts
+++ b/src/components/tests/tasks/Task.update.spec.ts
@@ -1,8 +1,20 @@
 import { type Task, updateTask } from "./Task";
 
 const base = (): Task[] => [
-  { id: 1, title: "Köp mjölk", completed: false },
-  { id: 2, title: "Städa", completed: true },
+  {
+    id: 1,
+    title: "Köp mjölk",
+    category: "Shop", //lagt till category och date - inget annat ändrat
+    date: new Date("2025-09-24"),
+    completed: false,
+  },
+  {
+    id: 2,
+    title: "Städa",
+    category: "Shop", //lagt till category och date - inget annat ändrat
+    date: new Date("2025-09-24"),
+    completed: true,
+  },
 ];
 
 describe("updateTask (lean)", () => {

--- a/src/utils/Tasklist.ts
+++ b/src/utils/Tasklist.ts
@@ -1,46 +1,42 @@
 import { Task } from "@/components/tests/tasks/Task";
 
-export interface DatedTask extends Task {
-  date: Date;
-}
-
-export function sortByTitle(tasks: DatedTask[]): DatedTask[] {
+export function sortByTitle(tasks: Task[]): Task[] {
   return [...tasks].sort((a, b) => {
     const cmp = a.title.localeCompare(b.title, "sv", { sensitivity: "base" });
     return cmp !== 0 ? cmp : a.id - b.id;
   });
 }
 
-export function sortByDateAsc(tasks: DatedTask[]): DatedTask[] {
+export function sortByDateAsc(tasks: Task[]): Task[] {
   return [...tasks].sort((a, b) => {
     const cmp = a.date.getTime() - b.date.getTime();
     return cmp !== 0 ? cmp : a.id - b.id;
   });
 }
 
-export function sortByDateDesc(tasks: DatedTask[]): DatedTask[] {
+export function sortByDateDesc(tasks: Task[]): Task[] {
   return [...tasks].sort((a, b) => {
     const cmp = b.date.getTime() - a.date.getTime();
     return cmp !== 0 ? cmp : a.id - b.id;
   });
 }
 
-export function filterCompleted(tasks: DatedTask[]): DatedTask[] {
+export function filterCompleted(tasks: Task[]): Task[] {
   return tasks.filter(t => t.completed);
 }
 
-export function filterTodo(tasks: DatedTask[]): DatedTask[] {
+export function filterTodo(tasks: Task[]): Task[] {
   return tasks.filter(t => !t.completed);
 }
 
-export function countAll(tasks: DatedTask[]): number {
+export function countAll(tasks: Task[]): number {
   return tasks.length;
 }
 
-export function countTodo(tasks: DatedTask[]): number {
+export function countTodo(tasks: Task[]): number {
   return tasks.filter(t => !t.completed).length;
 }
 
-export function countCompleted(tasks: DatedTask[]): number {
+export function countCompleted(tasks: Task[]): number {
   return tasks.filter(t => t.completed).length;
 }


### PR DESCRIPTION
Jag lade till category och date i interface Task och fick då lägga till dem i const base och const fresh men ingen ändring har gjorts i testerna. Nu passerar dem på grund av att alla fälten finns med.