### PR TITLE
feat(calendar-view): add category and status filtering to events

### DIFF
--- a/src/components/CalenderView.tsx
+++ b/src/components/CalenderView.tsx
@@ -1,7 +1,7 @@
 import dayGridPlugin from "@fullcalendar/daygrid";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import * as styledComponents from "styled-components";
 
 import userTasksData from "../Data/user_tasks.json";
@@ -9,6 +9,7 @@ import AddTaskCard from "./AddTaskCard";
 import { CategoryKey, CATEGORY_COLORS } from "../utils/categories";
 
 import TaskOverlay from "./TaskOverlay"; 
+import SortFilterBar, { SortMode, StatusFilter } from "./SortFilterBar";
 
 interface CalendarViewProps {
   userEmail: string;
@@ -32,13 +33,38 @@ export default function CalendarView({
     "" as CategoryKey
   ); // default none
 
-   const [selectedEvent, setSelectedEvent] = useState<{
+  const [selectedEvent, setSelectedEvent] = useState<{
     id: string;
     title: string;
     start: string;
     allDay: boolean;
     category: CategoryKey;
-  } | null>(null); // ADDED
+  } | null>(null);
+
+  const [activeCategory, setActiveCategory] = useState<CategoryKey | "all">(
+    "all"
+  );
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+
+   const visibleEvents = useMemo(() => {
+    let list = events;
+
+    if (activeCategory !== "all") {
+      list = list.filter(
+        (e: any) => e?.extendedProps?.category === activeCategory
+      );
+    }
+
+    if (statusFilter !== "all") {
+      const wantDone = statusFilter === "completed";
+      list = list.filter(
+        (e: any) => Boolean(e?.extendedProps?.done) === wantDone
+      );
+    }
+
+    return list;
+  }, [events, activeCategory, statusFilter]);
+
 
   const handleAddTask = (e: React.FormEvent) => {
     e.preventDefault();
@@ -158,6 +184,12 @@ export default function CalendarView({
         canSubmit={canSubmit}
         handleAddTask={handleAddTask}
       />
+      <SortFilterBar
+        activeCategory={activeCategory}
+        onCategoryChange={setActiveCategory}
+        statusFilter={statusFilter}
+        onStatusChange={setStatusFilter}
+      />
 
       <FullCalendar
         plugins={[dayGridPlugin, timeGridPlugin]}
@@ -167,7 +199,7 @@ export default function CalendarView({
           center: "title",
           right: "dayGridMonth,timeGridWeek,timeGridDay",
         }}
-        events={events}
+        events={visibleEvents}
         height="auto"
         locale="en"
         buttonText={{

--- a/src/components/SortFilterBar.tsx
+++ b/src/components/SortFilterBar.tsx
@@ -1,0 +1,69 @@
+// src/components/SortFilterBar.tsx
+import * as styledComponents from "styled-components";
+
+import {
+  CATEGORY_LABELS,
+  CATEGORY_OPTIONS,
+  CategoryKey,
+} from "../utils/categories";
+
+const styled = styledComponents.default;
+
+export type SortMode =
+  | "default"
+  | "title-asc"
+  | "title-desc"
+  | "completed-last";
+export type StatusFilter = "all" | "todo" | "completed";
+
+type Props = {
+  activeCategory: CategoryKey | "all";
+  onCategoryChange: (v: CategoryKey | "all") => void;
+  statusFilter: StatusFilter;
+  onStatusChange: (v: StatusFilter) => void;
+};
+
+export default function SortFilterBar({
+  activeCategory,
+  onCategoryChange,
+  statusFilter,
+  onStatusChange,
+}: Props) {
+  return (
+    <Bar>
+      <Select
+        value={activeCategory}
+        onChange={e => onCategoryChange(e.target.value as any)}
+      >
+        <option value="all">All categories</option>
+        {CATEGORY_OPTIONS.map(o => (
+          <option key={o.key} value={o.key}>
+            {CATEGORY_LABELS[o.key]}
+          </option>
+        ))}
+      </Select>
+
+      <Select
+        value={statusFilter}
+        onChange={e => onStatusChange(e.target.value as any)}
+      >
+        <option value="all">All status</option>
+        <option value="todo">Todo</option>
+        <option value="completed">Completed</option>
+      </Select>
+    </Bar>
+  );
+}
+
+const Bar = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin: 12px 0;
+`;
+const Select = styled.select`
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: #fff;
+`;


### PR DESCRIPTION
Introduced useMemo to derive visibleEvents from events
Added filtering by activeCategory and statusFilter (all/todo/completed)
Updated FullCalendar to render visibleEvents instead of raw events
Ensured extendedProps include category and done flags for correct filtering