### PR TITLE
fix(category-dropdown-addtask): add placeholder and CategorySelection…

### DIFF
--- a/src/components/AddTaskCard.tsx
+++ b/src/components/AddTaskCard.tsx
@@ -133,15 +133,11 @@ export default function AddTaskCard({
           >
             {/* Riktig placeholder – ej valbar */}
             <option value="" disabled hidden>
-              Välj kategori…
+              Select category…
             </option>
 
             {CATEGORY_OPTIONS.map(opt => (
-              <option
-                key={opt.key}
-                value={opt.key}
-                // TA BORT: disabled={opt.key === "none"}
-              >
+              <option key={opt.key} value={opt.key}>
                 {opt.label}
               </option>
             ))}

--- a/src/components/CalenderView.tsx
+++ b/src/components/CalenderView.tsx
@@ -8,7 +8,7 @@ import userTasksData from "../Data/user_tasks.json";
 import AddTaskCard from "./AddTaskCard";
 import { CategoryKey, CATEGORY_COLORS } from "../utils/categories";
 
-import TaskOverlay from "./TaskOverlay"; 
+import TaskOverlay from "./TaskOverlay";
 import SortFilterBar, { SortMode, StatusFilter } from "./SortFilterBar";
 
 interface CalendarViewProps {
@@ -46,7 +46,7 @@ export default function CalendarView({
   );
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
 
-   const visibleEvents = useMemo(() => {
+  const visibleEvents = useMemo(() => {
     let list = events;
 
     if (activeCategory !== "all") {
@@ -65,22 +65,23 @@ export default function CalendarView({
     return list;
   }, [events, activeCategory, statusFilter]);
 
-
   const handleAddTask = (e: React.FormEvent) => {
     e.preventDefault();
     const title = newTitle.trim();
-    if (!title || !newDate || newCategory === "none") return;
+    if (!title || !newDate || newCategory === "") return;
 
     const id = Date.now().toString();
     const start = newAllDay || !newTime ? newDate : `${newDate}T${newTime}:00`;
+
+    const cat = newCategory as Exclude<CategoryKey, "none">;
 
     const newEvent = {
       id,
       title,
       start,
-      backgroundColor: CATEGORY_COLORS[newCategory], // färgen = kategori
+      backgroundColor: CATEGORY_COLORS[cat],
       allDay: newAllDay || !newTime,
-      extendedProps: { category: newCategory, done: false }, // spara kategori i eventet
+      extendedProps: { category: cat, done: false },
     };
 
     setEvents(prev => [...prev, newEvent]);
@@ -90,11 +91,12 @@ export default function CalendarView({
     setNewTime("");
     setNewAllDay(true);
     setNewDate(new Date().toISOString().slice(0, 10));
-    setNewCategory("none"); // tillbaka till placeholder
+    setNewCategory("" as CategoryKey); // tillbaka till placeholder
   };
 
+  // canSubmit – kräv vald kategori
   const canSubmit =
-    newTitle.trim().length > 0 && !!newDate && newCategory !== "none";
+    newTitle.trim().length > 0 && !!newDate && newCategory !== "";
 
   useEffect(() => {
     const currentUser = userTasksData.find(

--- a/src/utils/categories.ts
+++ b/src/utils/categories.ts
@@ -1,13 +1,6 @@
-export type CategoryKey =
-  | "none"
-  | "work"
-  | "home"
-  | "health"
-  | "family"
-  | "personal";
+export type CategoryKey = "work" | "home" | "health" | "family" | "personal";
 
 export const CATEGORY_LABELS: Record<CategoryKey, string> = {
-  none: "— Select category —",
   work: "Work / Studies",
   home: "Home / Household",
   health: "Health / Well-being",
@@ -16,7 +9,6 @@ export const CATEGORY_LABELS: Record<CategoryKey, string> = {
 };
 
 export const CATEGORY_COLORS: Record<CategoryKey, string> = {
-  none: "#9ca3af", // neutral grå (placeholder)
   work: "#2563eb", // blå
   home: "#10b981", // grön
   health: "#ef4444", // röd
@@ -25,7 +17,6 @@ export const CATEGORY_COLORS: Record<CategoryKey, string> = {
 };
 
 export const CATEGORY_OPTIONS: Array<{ key: CategoryKey; label: string }> = [
-  { key: "none", label: CATEGORY_LABELS.none },
   { key: "work", label: CATEGORY_LABELS.work },
   { key: "home", label: CATEGORY_LABELS.home },
   { key: "health", label: CATEGORY_LABELS.health },


### PR DESCRIPTION
Fixar kategorirullistan i AddTaskCard:

- Lagt till en riktig placeholder: “Select category…” som visas innan användaren gjort ett val.
- Begränsat dropdown-listan till endast fem riktiga kategorier (work, home, health, family, personal).
- Uppdaterat validering så att det inte går att skapa en uppgift utan kategori.
- Rensar tillbaka till placeholder när en uppgift har sparats.

Användaren ser nu alltid “Select category…” innan val.