### PR TITLE
chore(eslint): ignore Cypress config file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,5 @@ commitlint.config.js
 jest.config.js
 postcss.config.js
 *.d.ts
+cypress.config.cjs
+


### PR DESCRIPTION
This PR updates .eslintignore to exclude cypress.config.cjs.
ESLint was previously trying to parse the Cypress config as TypeScript, causing errors.
Ignoring this file ensures linting runs cleanly without affecting Cypress itself.