### PR TITLE
fix(calendar-view): add 24h format for time axis labels

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -202,6 +202,12 @@ export default function CalendarView({
                 day: "Day",
               }}
               eventDisplay="block"
+              /* NYTT: 24h på tidsaxeln */
+              slotLabelFormat={{
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false,
+              }}
               eventTimeFormat={{
                 hour: "2-digit",
                 minute: "2-digit",


### PR DESCRIPTION
- Uppdaterat FullCalendar-konfigurationen för att visa tider i 24h-format istället för AM/PM.
- Använder `slotLabelFormat` och `eventTimeFormat` med `hour12: false`.

- Gör det enklare att läsa tider i kalendern.
- Anpassat för svenska användare som förväntar sig digitalt klockslag.

- Verifierat i vyerna `timeGridWeek` och `timeGridDay`.
- Events och tidsaxel visar nu 24h-format (ex: 15:30 istället för 3:30pm).
